### PR TITLE
Don't re-pack failure image

### DIFF
--- a/assertions/visualRegression.js
+++ b/assertions/visualRegression.js
@@ -146,7 +146,8 @@ exports.assertion = function(selector, label, msg) {
 
         // On a failure, save the diff file to the error folder
         if( failed && result ){
-            result.getDiffImage().pack().pipe(fse.createWriteStream(errorFilename));
+            // Already packed earlier, when diff file written
+            result.getDiffImage().pipe(fse.createWriteStream(errorFilename));
 
             this.message = util.format('Visual Regression: Screen differs by %s% (see: %s)', selElement, this.value(result), errorFilename);
         }


### PR DESCRIPTION
Fixes #2

Diff image was already packed when the diff was written.  Packing again results in errors.
