### PR TITLE
Fixes #15 - Scroll element into view first

### DIFF
--- a/assertions/visualRegression.js
+++ b/assertions/visualRegression.js
@@ -265,7 +265,7 @@ exports.assertion = function(selector, label, msg) {
                 if( selElement ){
 
                     // This was failing called within the saveScreenshot callback, so moved here
-                    this.getLocation(selector||selElement, function(results){
+                    this.getLocationInView(selector||selElement, function(results){
                         var origin = results.value;
 
                         this.getElementSize(selector || selElement, function(results){


### PR DESCRIPTION
Before getting the location of the element, capturing the screenshot, and saving; make sure the element is in view.  Especially in chrome, the screenshot is constrained to the viewport, so an element may not be in the saved screenshot if it is outside of the viewport.  Use getLocationInView to first move the element into view.